### PR TITLE
Human readable unexpected body error

### DIFF
--- a/auditlogsreceiver/audit_logs.go
+++ b/auditlogsreceiver/audit_logs.go
@@ -192,7 +192,7 @@ func (a *auditLogsReceiver) processResponseBody(ctx context.Context, body []byte
 	var auditLogsMap map[string]interface{}
 	err := json.Unmarshal(body, &auditLogsMap)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unexpected body in response: %v", body)
+		return nil, nil, fmt.Errorf("unexpected body in response: %v", string(body))
 	}
 
 	lastAuditLogTimestamp, err := a.processAuditLogs(ctx, auditLogsMap)


### PR DESCRIPTION
In the case of failure of unmarshaling audit log response byte array is logged, which pollutes logs with non-human readable information. Instead, log the response body as a string. 