### PR TITLE
Add splunk integration for audit log reciever

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,15 @@ build-datadog: build
 .PHONY: run-datadog-docker
 run-datadog-docker: build-datadog
 	cd examples/datadog && docker compose up --build
+
+.PHONY: build-splunk
+build-splunk: BUILD_ARGS:=GOOS=linux
+build-splunk: build
+	# Build for multiple architectures
+	cd castai-collector && \
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o castai-collector-amd64 && \
+	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o castai-collector-arm64
+
+.PHONY: run-splunk-docker
+run-splunk-docker: build-splunk
+	cd examples/splunk && docker compose up --build

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -24,6 +24,7 @@ exporters:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter v0.119.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter v0.119.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.119.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.119.0
 
 replaces:
   # Override Lokiexporter dependencies.

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -16,6 +16,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.119.0
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.119.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.119.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.119.0
 
 
 exporters:

--- a/examples/splunk/.env
+++ b/examples/splunk/.env
@@ -1,11 +1,11 @@
-SPLUNK_SITE=prd-p-y7wa7.splunkcloud.com:8088/services/collector/event
-SPLUNK_KEY=
-CASTAI_API_KEY=5734ffe56a8e4167194200bacda2fd52b04550da6d593518de08763d474c93f7
+SPLUNK_SITE=https://prd-p-vqewh.splunkcloud.com:8088/services/collector/event
+SPLUNK_HEC_TOKEN=64100170-9a5a-45fd-911e-e86f3e81a3fb
+CASTAI_API_KEY=
 CASTAI_API_URL=https://api.cast.ai
 CASTAI_CLUSTER_ID=0c40d3f3-6a79-411c-96e3-dbba9572e988
 
-
-# curl -k https://prd-p-y7wa7.splunkcloud.com:8088/services/collector/event \
-#      -H "Authorization: Splunk " \
+# Test curl
+# curl -k https://prd-p-vqewh.splunkcloud.com:8088/services/collector/event \
+#      -H "Authorization: Splunk 64100170-9a5a-45fd-911e-e86f3e81a3fb" \
 #      -H "Content-Type: application/json" \
-#      -d '{"event": "hello world"}'
+#      -d '{"event": "yahoo world"}'

--- a/examples/splunk/.env
+++ b/examples/splunk/.env
@@ -1,0 +1,11 @@
+SPLUNK_SITE=prd-p-y7wa7.splunkcloud.com:8088/services/collector/event
+SPLUNK_KEY=
+CASTAI_API_KEY=5734ffe56a8e4167194200bacda2fd52b04550da6d593518de08763d474c93f7
+CASTAI_API_URL=https://api.cast.ai
+CASTAI_CLUSTER_ID=0c40d3f3-6a79-411c-96e3-dbba9572e988
+
+
+# curl -k https://prd-p-y7wa7.splunkcloud.com:8088/services/collector/event \
+#      -H "Authorization: Splunk " \
+#      -H "Content-Type: application/json" \
+#      -d '{"event": "hello world"}'

--- a/examples/splunk/.env
+++ b/examples/splunk/.env
@@ -1,11 +1,5 @@
-SPLUNK_SITE=https://prd-p-vqewh.splunkcloud.com:8088/services/collector/event
-SPLUNK_HEC_TOKEN=64100170-9a5a-45fd-911e-e86f3e81a3fb
+SPLUNK_SITE=
+SPLUNK_HEC_TOKEN=
 CASTAI_API_KEY=
 CASTAI_API_URL=https://api.cast.ai
-CASTAI_CLUSTER_ID=0c40d3f3-6a79-411c-96e3-dbba9572e988
-
-# Test curl
-# curl -k https://prd-p-vqewh.splunkcloud.com:8088/services/collector/event \
-#      -H "Authorization: Splunk 64100170-9a5a-45fd-911e-e86f3e81a3fb" \
-#      -H "Content-Type: application/json" \
-#      -d '{"event": "yahoo world"}'
+CASTAI_CLUSTER_ID=

--- a/examples/splunk/Dockerfile
+++ b/examples/splunk/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:latest
+RUN apk --update add ca-certificates
+
+ARG TARGETARCH
+COPY castai-collector/castai-collector-${TARGETARCH} /castai-collector
+COPY examples/splunk/collector-config.yaml /etc/otel/config.yaml
+
+ENTRYPOINT ["/castai-collector"]
+CMD ["--config", "/etc/otel/config.yaml"]

--- a/examples/splunk/collector-config.yaml
+++ b/examples/splunk/collector-config.yaml
@@ -39,8 +39,8 @@ exporters:
   debug:
     verbosity: detailed
   splunk_hec:
-    token: "64100170-9a5a-45fd-911e-e86f3e81a3fb"
-    endpoint: "https://prd-p-vqewh.splunkcloud.com:8088/services/collector"
+    token: ${env:SPLUNK_HEC_TOKEN}
+    endpoint: ${env:SPLUNK_SITE}
     source: "castai-audit"
     sourcetype: "manual"
     index: "main"
@@ -57,5 +57,5 @@ service:
   pipelines:
     logs:
       receivers: [castai_audit_logs]
-      processors: [transform, attributes]  # Added transform first
+      processors: [transform, attributes, batch]  # Added transform first
       exporters: [debug, splunk_hec]

--- a/examples/splunk/collector-config.yaml
+++ b/examples/splunk/collector-config.yaml
@@ -1,0 +1,52 @@
+receivers:
+  castai_audit_logs:
+    api:
+      url: ${env:CASTAI_API_URL}
+      key: ${env:CASTAI_API_KEY}
+    poll_interval_sec: 10
+    page_limit: 100
+    storage:
+      type: "persistent"
+      filename: "./audit_logs_poll_data.json"
+    # filters:
+    #   cluster_id: ${env:CASTAI_CLUSTER_ID}
+
+processors:
+  resource:
+    attributes:
+      - key: deployment.environment
+        value: "castai-audit"
+        action: upsert
+  batch:
+    timeout: 10s
+    send_batch_size: 1
+
+exporters:
+  splunk_hec:
+    # Splunk HTTP Event Collector token.
+    token: ""
+    # URL to a Splunk instance to send data to.
+    endpoint: "https://prd-p-y7wa7.splunkcloud.com:8088/services/collector/event"
+    # Optional Splunk source: https://docs.splunk.com/Splexicon:Source
+    source: "http:test-ronk"
+    # # # Optional Splunk source type: https://docs.splunk.com/Splexicon:Sourcetype
+    # sourcetype: "otel"
+    # # # Splunk index, optional name of the Splunk index targeted.
+    # index: "metrics"
+    # Whether to disable gzip compression over HTTP. Defaults to false.
+    disable_compression: false
+    # HTTP timeout when sending data. Defaults to 10s.
+    timeout: 10s
+    # Whether to skip checking the certificate of the HEC endpoint when sending data over HTTPS. Defaults to false.
+    # For this demo, we use a self-signed certificate on the Splunk docker instance, so this flag is set to true.
+    tls:
+      insecure_skip_verify: false
+service:
+  telemetry:
+    logs:
+      level: "debug"
+  pipelines:
+    logs:
+      receivers: [castai_audit_logs]
+      processors: [resource, batch]
+      exporters: [splunk_hec]

--- a/examples/splunk/collector-config.yaml
+++ b/examples/splunk/collector-config.yaml
@@ -30,7 +30,7 @@ exporters:
     # Splunk HTTP Event Collector token.
     token: "64100170-9a5a-45fd-911e-e86f3e81a3fb"
     # URL to a Splunk instance to send data to.
-    endpoint: "https://http-inputs-prd-p-vqewh.splunkcloud.com:8088/services/collector"
+    endpoint: "https://prd-p-vqewh.splunkcloud.com:8088/services/collector"
     # Optional Splunk source: https://docs.splunk.com/Splexicon:Source
     source: "http:http-test"
     # # # # Optional Splunk source type: https://docs.splunk.com/Splexicon:Sourcetype

--- a/examples/splunk/collector-config.yaml
+++ b/examples/splunk/collector-config.yaml
@@ -23,14 +23,18 @@ processors:
 
 exporters:
   splunk_hec:
+    retry_on_failure:
+      enabled: true
+    log_data_enabled: true
+    health_check_enabled: true
     # Splunk HTTP Event Collector token.
-    token: ""
+    token: "64100170-9a5a-45fd-911e-e86f3e81a3fb"
     # URL to a Splunk instance to send data to.
-    endpoint: "https://prd-p-y7wa7.splunkcloud.com:8088/services/collector/event"
+    endpoint: "https://http-inputs-prd-p-vqewh.splunkcloud.com:8088/services/collector"
     # Optional Splunk source: https://docs.splunk.com/Splexicon:Source
-    source: "http:test-ronk"
-    # # # Optional Splunk source type: https://docs.splunk.com/Splexicon:Sourcetype
-    # sourcetype: "otel"
+    source: "http:http-test"
+    # # # # Optional Splunk source type: https://docs.splunk.com/Splexicon:Sourcetype
+    # sourcetype: "_json"
     # # # Splunk index, optional name of the Splunk index targeted.
     # index: "metrics"
     # Whether to disable gzip compression over HTTP. Defaults to false.
@@ -40,7 +44,8 @@ exporters:
     # Whether to skip checking the certificate of the HEC endpoint when sending data over HTTPS. Defaults to false.
     # For this demo, we use a self-signed certificate on the Splunk docker instance, so this flag is set to true.
     tls:
-      insecure_skip_verify: false
+      insecure_skip_verify: true
+
 service:
   telemetry:
     logs:
@@ -48,5 +53,5 @@ service:
   pipelines:
     logs:
       receivers: [castai_audit_logs]
-      processors: [resource, batch]
+      # processors: [resource, batch]
       exporters: [splunk_hec]

--- a/examples/splunk/collector-config.yaml
+++ b/examples/splunk/collector-config.yaml
@@ -1,50 +1,54 @@
 receivers:
   castai_audit_logs:
     api:
-      url: ${env:CASTAI_API_URL}
-      key: ${env:CASTAI_API_KEY}
-    poll_interval_sec: 10
+      url: "https://api.cast.ai"
+      key:  ${env:CASTAI_API_KEY}
+    poll_interval_sec: 60
     page_limit: 100
     storage:
       type: "persistent"
-      filename: "./audit_logs_poll_data.json"
-    # filters:
-    #   cluster_id: ${env:CASTAI_CLUSTER_ID}
+      filename: "/data/audit_logs_poll_data.json"
 
 processors:
-  resource:
-    attributes:
-      - key: deployment.environment
-        value: "castai-audit"
-        action: upsert
+  transform:
+    error_mode: ignore
+    log_statements:
+      - context: log
+        statements:
+          - set(body, attributes) where IsMap(attributes)
+          - set(attributes["source"], "castai-audit")
+          - set(attributes["sourcetype"], "manual")
+
+  attributes:
+    actions:
+      - key: "simple_message"
+        value: "CAST AI Event"
+        action: insert  
+
   batch:
     timeout: 10s
     send_batch_size: 1
+  
+  resource:
+    attributes:
+      - key: service.name
+        value: castai-audit-logs-collector
+        action: upsert
 
 exporters:
+  debug:
+    verbosity: detailed
   splunk_hec:
-    retry_on_failure:
-      enabled: true
-    log_data_enabled: true
-    health_check_enabled: true
-    # Splunk HTTP Event Collector token.
     token: "64100170-9a5a-45fd-911e-e86f3e81a3fb"
-    # URL to a Splunk instance to send data to.
     endpoint: "https://prd-p-vqewh.splunkcloud.com:8088/services/collector"
-    # Optional Splunk source: https://docs.splunk.com/Splexicon:Source
-    source: "http:http-test"
-    # # # # Optional Splunk source type: https://docs.splunk.com/Splexicon:Sourcetype
-    # sourcetype: "_json"
-    # # # Splunk index, optional name of the Splunk index targeted.
-    # index: "metrics"
-    # Whether to disable gzip compression over HTTP. Defaults to false.
-    disable_compression: false
-    # HTTP timeout when sending data. Defaults to 10s.
-    timeout: 10s
-    # Whether to skip checking the certificate of the HEC endpoint when sending data over HTTPS. Defaults to false.
-    # For this demo, we use a self-signed certificate on the Splunk docker instance, so this flag is set to true.
+    source: "castai-audit"
+    sourcetype: "manual"
+    index: "main"
     tls:
       insecure_skip_verify: true
+    log_data_enabled: true
+    timeout: 30s
+    disable_compression: true
 
 service:
   telemetry:
@@ -53,5 +57,5 @@ service:
   pipelines:
     logs:
       receivers: [castai_audit_logs]
-      # processors: [resource, batch]
-      exporters: [splunk_hec]
+      processors: [transform, attributes]  # Added transform first
+      exporters: [debug, splunk_hec]

--- a/examples/splunk/docker-compose.yaml
+++ b/examples/splunk/docker-compose.yaml
@@ -1,0 +1,15 @@
+services:
+  otelcol:
+    build:
+      context: ../..
+      dockerfile: examples/splunk/Dockerfile
+      args:
+        TARGETARCH: ${TARGETARCH:-amd64}
+    environment:
+      - SPLUNK_SITE=${SPLUNK_SITE}
+      - SPLUNK_KEY=${SPLUNK_KEY}
+      - CASTAI_API_URL=${CASTAI_API_URL:-https://api.cast.ai}
+      - CASTAI_API_KEY=${CASTAI_API_KEY}
+      - CASTAI_CLUSTER_ID=${CASTAI_CLUSTER_ID}
+    volumes:
+      - ./data:/data

--- a/examples/splunk/docker-compose.yaml
+++ b/examples/splunk/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
         TARGETARCH: ${TARGETARCH:-amd64}
     environment:
       - SPLUNK_SITE=${SPLUNK_SITE}
-      - SPLUNK_KEY=${SPLUNK_KEY}
+      - SPLUNK_HEC_TOKEN=${SPLUNK_HEC_TOKEN}
       - CASTAI_API_URL=${CASTAI_API_URL:-https://api.cast.ai}
       - CASTAI_API_KEY=${CASTAI_API_KEY}
       - CASTAI_CLUSTER_ID=${CASTAI_CLUSTER_ID}


### PR DESCRIPTION
**Summary**
Adds Splunk integration to the CAST AI Audit Log Receiver

**Changes**
Integrated OpenTelemetry Splunk exporter (v0.119.0)
Integrated Transform processor to convert audit logs to splunk desired format
