### PR TITLE
fix: Adding proxy variable for customer that has network traffic blocked

### DIFF
--- a/examples/datadog/.env
+++ b/examples/datadog/.env
@@ -3,3 +3,4 @@ DD_API_KEY=<datadog-api-key>
 CASTAI_API_KEY=<castai-api-key>
 CASTAI_API_URL=https://api.cast.ai
 CASTAI_CLUSTER_ID=<cluster_id>
+PROXY=http://proxy.yourcompany.com:8080 #Some companies has traffic blocked, and a proxy must be provided in order to allow communication between source and destination

--- a/examples/datadog/collector-config.yaml
+++ b/examples/datadog/collector-config.yaml
@@ -24,6 +24,7 @@ processors:
 exporters:
   datadog:
     hostname: "castai-collector"
+    proxy_url: ${env:PROXY}
     api:
       site: ${env:DD_SITE}
       key: ${env:DD_API_KEY}


### PR DESCRIPTION
Customers reported that has traffic blocked on their network, in order to allow the communication between source and destination, a proxy must be provided. 
I have added the config on exporters and setup a new env variable in order to attend this requirement

