### PR TITLE
feat: Replace loki exporter with otltp http exporter, bump deps

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,13 +20,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Go 1.24.4
+      - name: Setup Go 1.25.3
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.4
+          go-version: 1.25.3
 
       - name: Install dependency
-        run: go install go.opentelemetry.io/collector/cmd/builder@v0.129.0
+        run: go install go.opentelemetry.io/collector/cmd/builder@v0.138.0
 
       - name: Get release tag
         if: github.event_name == 'release'

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -11,12 +11,12 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.25.3
-      - uses: actions/checkout@v3
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          args: --timeout=5m
-          working-directory: auditlogsreceiver
+          go-version: '1.25.3'
+      - name: Install golangci-lint from source
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+      - name: Run golangci-lint
+        run: golangci-lint run --timeout=5m
+        working-directory: auditlogsreceiver

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.24.4
+          go-version: 1.25.3
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GOARCH := $(shell go env GOARCH)
 .PHONY: setup # Set up required tools (builder, mdatagen)
 setup:
 	git clone https://github.com/open-telemetry/opentelemetry-collector.git ./opentelemetry-collector
-	cd ./opentelemetry-collector && git checkout v0.129.0
+	cd ./opentelemetry-collector && git checkout v0.138.0
 	cd ./opentelemetry-collector/cmd/builder && go build -o builder .
 	cd ./opentelemetry-collector/cmd/mdatagen && go build -o mdatagen .
 

--- a/README.md
+++ b/README.md
@@ -99,26 +99,34 @@ Default image used in chart, which is `us-docker.pkg.dev/castai-hub/library/audi
 
 Example Helm install with Loki configuration:
   * create your custom `values.yaml` with pipeline setup from [./examples/loki/collector-config.yaml](./examples/loki/collector-config.yaml):  
+  * Make sure your loki config has `resource_attributes` set so they become labels in Loki to filter by : [./examples/loki/loki-config.yaml](./examples/loki/loki-config.yaml):
 ```shell
 # values.yaml
 config:
   exporters:
-    loki:
-      endpoint: http://localhost:3100/loki/api/v1/push
+    otlphttp/loki:
+      endpoint: http://localhost:3100/otlp
 
   processors:
-    attributes: 
-      actions:
-        - action: insert
-          key: loki.attribute.labels
-          value: id, initiatedBy, eventType, labels.ClusterId
+    transform:
+      log_statements:
+        - context: log
+          statements:
+            # Move to resource attributes (these become Loki labels)
+            - set(resource.attributes["eventType"], attributes["eventType"]) where attributes["eventType"] != nil
+            - set(resource.attributes["id"], attributes["id"]) where attributes["id"] != nil
+            - set(resource.attributes["initiatedBy"], attributes["initiatedBy"]["id"]) where attributes["initiatedBy"]["id"] != nil
+            - set(resource.attributes["clusterId"], attributes["labels"]["clusterId"]) where attributes["labels"]["clusterId"] != nil
+  
+            # Convert all attributes to JSON string and set as body (always)
+            - set(body, attributes)
 
   service:
     pipelines:
       logs:
         receivers: [castai_audit_logs]
-        processors: [attributes]
-        exporters: [loki]
+        processors: [transform]
+        exporters: [otlphttp/loki]
 ```
 * deploy chart with `--values` flag set to `values.yaml`:
 ```shell

--- a/auditlogsreceiver/go.mod
+++ b/auditlogsreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/castai/audit-logs-receiver/audit-logs
 
-go 1.24.4
+go 1.25.3
 
 require (
 	github.com/go-resty/resty/v2 v2.16.5

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -4,29 +4,26 @@ dist:
   output_path: ./castai-collector
 
 receivers:
-  - gomod: github.com/castai/audit-logs-receiver/audit-logs v0.129.0
+  - gomod: github.com/castai/audit-logs-receiver/audit-logs v0.138.0
     import: github.com/castai/audit-logs-receiver/audit-logs
     name: "auditlogsreceiver"
     path: "./auditlogsreceiver/"
 
 extensions:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.129.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.138.0
 
 processors:
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.129.0
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.129.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.138.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.138.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.138.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.138.0
 
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/lokiexporter v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.129.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.138.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.138.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.138.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/coralogixexporter v0.138.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.138.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter v0.138.0
 
-replaces:
-  # Override Lokiexporter dependencies.
-  - google.golang.org/genproto => google.golang.org/genproto v0.0.0-20230530153820-e85fd2cbaebc

--- a/examples/loki/collector-config.yaml
+++ b/examples/loki/collector-config.yaml
@@ -10,16 +10,21 @@ receivers:
       filename: "./audit_logs_poll_data.json"
 
 exporters:
-  loki:
-    endpoint: http://localhost:3100/loki/api/v1/push
+  otlphttp/loki:
+    endpoint: http://localhost:3100/otlp
 
 processors:
-  attributes: 
-    actions:
-      - action: insert
-        key: loki.attribute.labels
-        value: id, initiatedBy, eventType, labels.ClusterId
+  transform:
+    log_statements:
+      - context: log
+        statements:
+          - set(resource.attributes["eventType"], attributes["eventType"]) where attributes["eventType"] != nil
+          - set(resource.attributes["id"], attributes["id"]) where attributes["id"] != nil
+          - set(resource.attributes["initiatedBy"], attributes["initiatedBy"]["id"]) where attributes["initiatedBy"]["id"] != nil
+          - set(resource.attributes["clusterId"], attributes["labels"]["clusterId"]) where attributes["labels"]["clusterId"] != nil
 
+          # Convert all attributes to JSON string and set as body.
+          - set(body, attributes)
 service:
   telemetry:
     logs:
@@ -27,5 +32,5 @@ service:
   pipelines:
     logs:
       receivers: [castai_audit_logs]
-      processors: [attributes]
-      exporters: [loki]
+      processors: [transform]
+      exporters: [otlphttp/loki]

--- a/examples/loki/docker-compose.yaml
+++ b/examples/loki/docker-compose.yaml
@@ -4,7 +4,7 @@ networks:
 
 services:
   loki:
-    image: grafana/loki:2.8.0
+    image: grafana/loki:3.5.7
     volumes:
       - ./loki-config.yaml:/etc/loki/loki-config.yaml
     ports:
@@ -14,7 +14,7 @@ services:
       - loki
 
   promtail:
-    image: grafana/promtail:2.8.0
+    image: grafana/promtail:3.5.3
     volumes:
       - /var/log:/var/log
     command: -config.file=/etc/promtail/config.yml
@@ -22,6 +22,7 @@ services:
       - loki
 
   grafana:
+    image: grafana/grafana:latest
     environment:
       - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
       - GF_AUTH_ANONYMOUS_ENABLED=true
@@ -45,7 +46,6 @@ services:
           editable: false
         EOF
         /run.sh
-    image: grafana/grafana:latest
     ports:
       - "3000:3000"
     networks:

--- a/examples/loki/loki-config.yaml
+++ b/examples/loki/loki-config.yaml
@@ -17,29 +17,39 @@ common:
 schema_config:
   configs:
     - from: 2020-10-24
-      store: boltdb-shipper
+      store: tsdb
       object_store: filesystem
-      schema: v11
+      schema: v13
       index:
         prefix: index_
         period: 24h
 
 limits_config:
-  max_cache_freshness_per_query: '10m'
-  enforce_metric_name: false
+  max_cache_freshness_per_query: 10m
+  allow_structured_metadata: true
   reject_old_samples: false
-  reject_old_samples_max_age: 8760h # 1y
+  reject_old_samples_max_age: 8760h
   ingestion_rate_mb: 10
   ingestion_burst_size_mb: 20
   split_queries_by_interval: 15m # parallelize queries in 15min intervals
   unordered_writes: true
-  max_query_length: 5000h # Default: 721h
-
-chunk_store_config:
-  max_look_back_period: 8760h # 1y
+  max_query_length: 5000h
+  otlp_config:
+    resource_attributes:
+      attributes_config:
+        - action: index_label
+          attributes:
+            - eventType
+            - id
+            - initiatedBy
+            - clusterId
 
 ingester:
-  max_chunk_age: 43800h # 5y
+  chunk_idle_period: 5m
+  chunk_target_size: 1048576
+  max_chunk_age: 8760h  # 1y
+  wal:
+    enabled: true
 
 ruler:
   alertmanager_url: http://localhost:9093


### PR DESCRIPTION
* Replacing deprecated loki exporter with `otlphttpexporter`
* Updated readme & loki example
* Bump go to version 1.25.3